### PR TITLE
Support older rubies by avoiding <<~

### DIFF
--- a/lib/good_migrations/patches_autoloader.rb
+++ b/lib/good_migrations/patches_autoloader.rb
@@ -27,7 +27,7 @@ module GoodMigrations
             end
           end
         else
-          warn <<~UNSUPPORTED
+          warn <<-UNSUPPORTED.strip_heredoc
             WARNING: good_migrations is unable to ensure that your migrations are
               not inadvertently loading application code, because your application
               uses the zeitwerk autoloader (`config.autoloader = :zeitwerk`), but

--- a/lib/good_migrations/prevents_app_load.rb
+++ b/lib/good_migrations/prevents_app_load.rb
@@ -5,7 +5,7 @@ module GoodMigrations
     end
 
     def self.prevent_load!(path)
-      raise GoodMigrations::LoadError, <<~ERROR
+      raise GoodMigrations::LoadError, <<-ERROR.strip_heredoc
         Rails attempted to auto-load:
 
         #{path}


### PR DESCRIPTION
We're still stuck with ruby 1.9.3 at work. We are working on upgrading, but that stuff takes time. Since it only takes 2 changes to bring compatibility back, here they are.