### PR TITLE
Add permit_autoload_before_date configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+* Add `permit_autoloading_before_date` configuration
+
 ## 0.1.0
 
 * Add support for zeitwerk@2.5 & higher

--- a/README.md
+++ b/README.md
@@ -56,14 +56,37 @@ good!
 For more background, see the last section of this blog post on [healthy migration
 habits](http://blog.testdouble.com/posts/2014-11-04-healthy-migration-habits.html)
 
-## Options
+## Adding to an existing app
 
-There's no public API to this gem. If you want to work around its behavior, you
-have a few options:
+If you add this to an existing app where past migrations had this problem, then those
+past migration will be failing.
 
-1. Run the command with the env var `GOOD_MIGRATIONS=skip`
-2. Explicitly `require` the app code you need in your migration
-3. Remove the gem from your project
+You have 2 options:
+* Rewrite those past migrations to not use external code
+* Use the `permit_autoloading_before_date` configuration (see below) to permit autoloading for
+  these older migrations
+
+## Configuration
+
+To configure, add those lines to an initializer (such as `config/initializers/config_good_migrations.rb`)
+ 
+#### permit_autoloading_before_date configuration
+
+```ruby
+GoodMigrations::Configuration.permit_autoloading_before_date = "2021-06-01"
+```
+
+Migrations with timestamps (the numbers at the beginning of the file name)
+from before this configured time will be allowed to perform autoloading, bypassing the mechanism of this gem. Accepts:
+* nil: meaning never permit autoloading
+* String accepted by `Time.parse`, such as '20211103150610', '20211103_150610' and '2021-01-01'
+* object responding to `to_time`, such as Date and Time
+
+## Working around good_migrations
+
+You can explicitly `require` the app code that you need in your migration.
+
+If needed, it is possible to run a command with `good_migrations` disabled by running the command with the env var `GOOD_MIGRATIONS=skip`.
 
 ## Acknowledgements
 

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -7,3 +7,5 @@ gem "good_migrations", path: ".."
 gem "sqlite3"
 
 gem "zeitwerk", github: "fxn/zeitwerk"
+
+gem "bootsnap", require: false

--- a/example/app/models/shirt.rb
+++ b/example/app/models/shirt.rb
@@ -1,0 +1,2 @@
+class Shirt < ActiveRecord::Base
+end

--- a/example/config/boot.rb
+++ b/example/config/boot.rb
@@ -13,3 +13,4 @@ if File.exist?(gemfile)
     exit!
   end
 end
+require "bootsnap/setup"

--- a/example/config/initializers/config_good_migrations.rb
+++ b/example/config/initializers/config_good_migrations.rb
@@ -1,0 +1,1 @@
+GoodMigrations::Configuration.permit_autoloading_before_date = ENV["PERMIT_BEFORE_DATE"]

--- a/example/config/initializers/config_good_migrations.rb
+++ b/example/config/initializers/config_good_migrations.rb
@@ -1,1 +1,1 @@
-GoodMigrations::Configuration.permit_autoloading_before_date = ENV["PERMIT_BEFORE_DATE"]
+GoodMigrations.config.permit_autoloading_before_date = ENV["PERMIT_BEFORE_DATE"]

--- a/example/db/migrate/20170101150000_create_shirts.rb
+++ b/example/db/migrate/20170101150000_create_shirts.rb
@@ -1,0 +1,8 @@
+class CreateShirts < ActiveRecord::Migration[4.2]
+  def change
+    create_table :shirts do |t|
+      t.integer :size
+      t.integer :color
+    end
+  end
+end

--- a/example/db/migrate/20170102150000_change_shirts_dangerously.rb
+++ b/example/db/migrate/20170102150000_change_shirts_dangerously.rb
@@ -1,0 +1,10 @@
+class ChangeShirtsDangerously < ActiveRecord::Migration[4.2]
+  def up
+    Shirt.find_each do |shirt|
+      # uh oh!
+    end
+  end
+
+  def down
+  end
+end

--- a/lib/good_migrations.rb
+++ b/lib/good_migrations.rb
@@ -1,5 +1,8 @@
+require "time"
+
 require "good_migrations/version"
 require "good_migrations/load_error"
+require "good_migrations/configuration"
 require "good_migrations/patches_autoloader"
 require "good_migrations/prevents_app_load"
 require "good_migrations/railtie" if defined?(Rails)

--- a/lib/good_migrations.rb
+++ b/lib/good_migrations.rb
@@ -4,5 +4,5 @@ require "good_migrations/version"
 require "good_migrations/load_error"
 require "good_migrations/configuration"
 require "good_migrations/patches_autoloader"
-require "good_migrations/prevents_app_load"
+require "good_migrations/logic"
 require "good_migrations/railtie" if defined?(Rails)

--- a/lib/good_migrations.rb
+++ b/lib/good_migrations.rb
@@ -1,8 +1,8 @@
 require "time"
 
-require "good_migrations/version"
-require "good_migrations/load_error"
-require "good_migrations/configuration"
-require "good_migrations/patches_autoloader"
-require "good_migrations/logic"
-require "good_migrations/railtie" if defined?(Rails)
+require_relative "good_migrations/version"
+require_relative "good_migrations/load_error"
+require_relative "good_migrations/configuration"
+require_relative "good_migrations/patches_autoloader"
+require_relative "good_migrations/logic"
+require_relative "good_migrations/railtie" if defined?(Rails)

--- a/lib/good_migrations.rb
+++ b/lib/good_migrations.rb
@@ -2,6 +2,7 @@ require "time"
 
 require_relative "good_migrations/version"
 require_relative "good_migrations/load_error"
+require_relative "good_migrations/migration_details"
 require_relative "good_migrations/configuration"
 require_relative "good_migrations/patches_autoloader"
 require_relative "good_migrations/logic"

--- a/lib/good_migrations/configuration.rb
+++ b/lib/good_migrations/configuration.rb
@@ -1,29 +1,34 @@
 module GoodMigrations
+  def self.config
+    @configuration ||= Configuration.new
+  end
+
   class Configuration
-    class << self
-      # Migrations with timestamps (the numbers at the beginning of the file name) from
-      # before this configured time will be allowed to perform autoloading, bypassing the
-      # mechanism of this gem. Accepts:
-      #   nil: meaning never permit it
-      #   String accepted by `Time.parse`, such as: 20211103150610 or 20211103_150610
-      #   object responding to `to_time`, such as Date and Time
-      def permit_autoloading_before_date=(value)
-        case value
-        when nil
-          # Stay nil
-        when String
-          value = Time.parse(value)
+    # Migrations with timestamps (the numbers at the beginning of the file name) from
+    # before this configured time will be allowed to perform autoloading, bypassing the
+    # mechanism of this gem. Accepts:
+    #   nil (default): never permit autoload
+    #   String accepted by `Time.parse`, such as: 20211103150610 or 20211103_150610
+    #   object responding to `to_time`, such as Date and Time
+    attr_reader :permit_autoloading_before_date
+    def permit_autoloading_before_date=(value)
+      case value
+      when nil
+        # Stay nil
+      when String
+        value = Time.parse(value)
+      else
+        if value.respond_to?(:to_time)
+          value = value.to_time
         else
-          if value.respond_to?(:to_time)
-            value = value.to_time
-          else
-            raise "Received an invalid value for permit_autoloading_before_date: #{value.inspect}"
-          end
+          raise "Received an invalid value for permit_autoloading_before_date: #{value.inspect}"
         end
-        @permit_autoloading_before_date = value
       end
-      attr_reader :permit_autoloading_before_date
-      Configuration.permit_autoloading_before_date = nil
+      @permit_autoloading_before_date = value
+    end
+
+    def initialize
+      @permit_autoloading_before_date = nil
     end
   end
 end

--- a/lib/good_migrations/configuration.rb
+++ b/lib/good_migrations/configuration.rb
@@ -1,0 +1,29 @@
+module GoodMigrations
+  class Configuration
+    class << self
+      # Migrations with timestamps (the numbers at the beginning of the file name) from
+      # before this configured time will be allowed to perform autoloading, bypassing the
+      # mechanism of this gem. Accepts:
+      #   nil: meaning never permit it
+      #   String accepted by `Time.parse`, such as: 20211103150610 or 20211103_150610
+      #   object responding to `to_time`, such as Date and Time
+      def permit_autoloading_before_date=(value)
+        case value
+        when nil
+          # Stay nil
+        when String
+          value = Time.parse(value)
+        else
+          if value.respond_to?(:to_time)
+            value = value.to_time
+          else
+            raise "Received an invalid value for permit_autoloading_before_date: #{value.inspect}"
+          end
+        end
+        @permit_autoloading_before_date = value
+      end
+      attr_reader :permit_autoloading_before_date
+      Configuration.permit_autoloading_before_date = nil
+    end
+  end
+end

--- a/lib/good_migrations/logic.rb
+++ b/lib/good_migrations/logic.rb
@@ -1,5 +1,35 @@
 module GoodMigrations
   class Logic
+    def self.currently_executing_migration_path
+      migrate_dir_path = Rails.root.join("db/migrate/").to_s
+      loc = caller.detect { |loc| loc.start_with?(migrate_dir_path) }
+      return if loc.nil?
+      loc.partition(":").first
+    end
+
+    def self.extract_time_from_migration_path(path)
+      timestamp_string = File.basename(path).partition("_").first
+      return if timestamp_string.size != 14
+      Time.parse(timestamp_string)
+    end
+
+    def self.permit_autoloading_based_on_migration_time?
+      return false if GoodMigrations::Configuration.permit_autoloading_before_date.nil?
+
+      migration_path = currently_executing_migration_path
+      return false if migration_path.nil?
+
+      migration_time = extract_time_from_migration_path(migration_path)
+      # Or should this raise?
+      return false if migration_time.nil?
+
+      migration_time < GoodMigrations::Configuration.permit_autoloading_before_date
+    end
+
+    def self.permit_autoloading_of_path?(path)
+      !app_path?(path) || permit_autoloading_based_on_migration_time?
+    end
+
     def self.app_path?(path)
       path.starts_with? File.join(Rails.application.root, "app")
     end

--- a/lib/good_migrations/logic.rb
+++ b/lib/good_migrations/logic.rb
@@ -1,5 +1,5 @@
 module GoodMigrations
-  class PreventsAppLoad
+  class Logic
     def self.app_path?(path)
       path.starts_with? File.join(Rails.application.root, "app")
     end

--- a/lib/good_migrations/logic.rb
+++ b/lib/good_migrations/logic.rb
@@ -1,7 +1,7 @@
 module GoodMigrations
   class Logic
     def self.permit_autoloading_based_on_migration_time?
-      permit_before_date = GoodMigrations::Configuration.permit_autoloading_before_date
+      permit_before_date = GoodMigrations.config.permit_autoloading_before_date
       migration_details = GoodMigrations::MigrationDetails.currently_executing
       migration_details.considered_before?(permit_before_date)
     end

--- a/lib/good_migrations/migration_details.rb
+++ b/lib/good_migrations/migration_details.rb
@@ -1,0 +1,29 @@
+module GoodMigrations
+  class MigrationDetails
+    attr_reader :path
+    def initialize(path)
+      @path = path
+    end
+
+    def self.currently_executing
+      migrate_dir_path = Rails.root.join("db/migrate/").to_s
+
+      loc = caller.detect { |loc| loc.start_with?(migrate_dir_path) }
+      return if loc.nil?
+      new(loc.partition(":").first)
+    end
+
+    def associated_time
+      timestamp_string = File.basename(@path).partition("_").first
+      return if timestamp_string.size != 14
+      Time.parse(timestamp_string)
+    end
+
+    def considered_before?(time)
+      return false if time.nil?
+      my_time = associated_time
+      return false if my_time.nil?
+      my_time < time
+    end
+  end
+end

--- a/lib/good_migrations/patches_autoloader.rb
+++ b/lib/good_migrations/patches_autoloader.rb
@@ -20,7 +20,7 @@ module GoodMigrations
           @disabled = false
           Rails.autoloaders.each do |loader|
             loader.on_load do |_, _, path|
-              if GoodMigrations::Logic.app_path?(path) &&
+              if !GoodMigrations::Logic.permit_autoloading_of_path?(path) &&
                   !GoodMigrations::PatchesAutoloader.instance.disabled?
                 GoodMigrations::Logic.prevent_load!(path)
               end
@@ -44,7 +44,7 @@ module GoodMigrations
         ActiveSupport::Dependencies.class_eval do
           extend Module.new {
             def load_file(path, const_paths = loadable_constants_for_path(path))
-              if GoodMigrations::Logic.app_path?(path) &&
+              if !GoodMigrations::Logic.permit_autoloading_of_path?(path) &&
                   !GoodMigrations::PatchesAutoloader.instance.disabled?
                 GoodMigrations::Logic.prevent_load!(path)
               else

--- a/lib/good_migrations/patches_autoloader.rb
+++ b/lib/good_migrations/patches_autoloader.rb
@@ -20,8 +20,8 @@ module GoodMigrations
           @disabled = false
           Rails.autoloaders.each do |loader|
             loader.on_load do |_, _, path|
-              if !GoodMigrations::Logic.permit_autoloading_of_path?(path) &&
-                  !GoodMigrations::PatchesAutoloader.instance.disabled?
+              if !GoodMigrations::PatchesAutoloader.instance.disabled? &&
+                  !GoodMigrations::Logic.permit_autoloading_of_path?(path)
                 GoodMigrations::Logic.prevent_load!(path)
               end
             end
@@ -44,8 +44,8 @@ module GoodMigrations
         ActiveSupport::Dependencies.class_eval do
           extend Module.new {
             def load_file(path, const_paths = loadable_constants_for_path(path))
-              if !GoodMigrations::Logic.permit_autoloading_of_path?(path) &&
-                  !GoodMigrations::PatchesAutoloader.instance.disabled?
+              if !GoodMigrations::PatchesAutoloader.instance.disabled? &&
+                  !GoodMigrations::Logic.permit_autoloading_of_path?(path)
                 GoodMigrations::Logic.prevent_load!(path)
               else
                 super

--- a/lib/good_migrations/patches_autoloader.rb
+++ b/lib/good_migrations/patches_autoloader.rb
@@ -20,9 +20,9 @@ module GoodMigrations
           @disabled = false
           Rails.autoloaders.each do |loader|
             loader.on_load do |_, _, path|
-              if GoodMigrations::PreventsAppLoad.app_path?(path) &&
+              if GoodMigrations::Logic.app_path?(path) &&
                   !GoodMigrations::PatchesAutoloader.instance.disabled?
-                GoodMigrations::PreventsAppLoad.prevent_load!(path)
+                GoodMigrations::Logic.prevent_load!(path)
               end
             end
           end
@@ -44,9 +44,9 @@ module GoodMigrations
         ActiveSupport::Dependencies.class_eval do
           extend Module.new {
             def load_file(path, const_paths = loadable_constants_for_path(path))
-              if GoodMigrations::PreventsAppLoad.app_path?(path) &&
+              if GoodMigrations::Logic.app_path?(path) &&
                   !GoodMigrations::PatchesAutoloader.instance.disabled?
-                GoodMigrations::PreventsAppLoad.prevent_load!(path)
+                GoodMigrations::Logic.prevent_load!(path)
               else
                 super
               end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class ConfigurationTest < Minitest::Test
+  def test_permit_autoloading_before_date_set_nil
+    GoodMigrations::Configuration.permit_autoloading_before_date = nil
+
+    assert_nil GoodMigrations::Configuration.permit_autoloading_before_date
+  end
+
+  def test_permit_autoloading_before_date_set_string
+    GoodMigrations::Configuration.permit_autoloading_before_date = "20210203"
+    assert_equal Time.new(2021, 2, 3), GoodMigrations::Configuration.permit_autoloading_before_date
+
+    GoodMigrations::Configuration.permit_autoloading_before_date = "20210203101112"
+    assert_equal Time.new(2021, 2, 3, 10, 11, 12), GoodMigrations::Configuration.permit_autoloading_before_date
+
+    GoodMigrations::Configuration.permit_autoloading_before_date = "20210203_121112"
+    assert_equal Time.new(2021, 2, 3, 12, 11, 12), GoodMigrations::Configuration.permit_autoloading_before_date
+
+    GoodMigrations::Configuration.permit_autoloading_before_date = "2021-04-03 12:11:12"
+    assert_equal Time.new(2021, 4, 3, 12, 11, 12), GoodMigrations::Configuration.permit_autoloading_before_date
+  end
+
+  def test_permit_autoloading_before_date_set_bad_string
+    assert_raises(ArgumentError) do
+      GoodMigrations::Configuration.permit_autoloading_before_date = "abc"
+    end
+  end
+
+  def test_permit_autoloading_before_date_set_date
+    GoodMigrations::Configuration.permit_autoloading_before_date = Date.new(2021, 4, 15)
+
+    assert_equal Time.new(2021, 4, 15), GoodMigrations::Configuration.permit_autoloading_before_date
+  end
+
+  def test_permit_autoloading_before_date_set_time
+    GoodMigrations::Configuration.permit_autoloading_before_date = Time.new(2021, 4, 20, 16, 17, 18)
+
+    assert_equal Time.new(2021, 4, 20, 16, 17, 18), GoodMigrations::Configuration.permit_autoloading_before_date
+  end
+end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,41 +1,45 @@
 require "test_helper"
 
 class ConfigurationTest < Minitest::Test
-  def test_permit_autoloading_before_date_set_nil
-    GoodMigrations::Configuration.permit_autoloading_before_date = nil
+  def setup
+    @config = GoodMigrations::Configuration.new
+  end
 
-    assert_nil GoodMigrations::Configuration.permit_autoloading_before_date
+  def test_permit_autoloading_before_date_set_nil
+    @config.permit_autoloading_before_date = nil
+
+    assert_nil @config.permit_autoloading_before_date
   end
 
   def test_permit_autoloading_before_date_set_string
-    GoodMigrations::Configuration.permit_autoloading_before_date = "20210203"
-    assert_equal Time.new(2021, 2, 3), GoodMigrations::Configuration.permit_autoloading_before_date
+    @config.permit_autoloading_before_date = "20210203"
+    assert_equal Time.new(2021, 2, 3), @config.permit_autoloading_before_date
 
-    GoodMigrations::Configuration.permit_autoloading_before_date = "20210203101112"
-    assert_equal Time.new(2021, 2, 3, 10, 11, 12), GoodMigrations::Configuration.permit_autoloading_before_date
+    @config.permit_autoloading_before_date = "20210203101112"
+    assert_equal Time.new(2021, 2, 3, 10, 11, 12), @config.permit_autoloading_before_date
 
-    GoodMigrations::Configuration.permit_autoloading_before_date = "20210203_121112"
-    assert_equal Time.new(2021, 2, 3, 12, 11, 12), GoodMigrations::Configuration.permit_autoloading_before_date
+    @config.permit_autoloading_before_date = "20210203_121112"
+    assert_equal Time.new(2021, 2, 3, 12, 11, 12), @config.permit_autoloading_before_date
 
-    GoodMigrations::Configuration.permit_autoloading_before_date = "2021-04-03 12:11:12"
-    assert_equal Time.new(2021, 4, 3, 12, 11, 12), GoodMigrations::Configuration.permit_autoloading_before_date
+    @config.permit_autoloading_before_date = "2021-04-03 12:11:12"
+    assert_equal Time.new(2021, 4, 3, 12, 11, 12), @config.permit_autoloading_before_date
   end
 
   def test_permit_autoloading_before_date_set_bad_string
     assert_raises(ArgumentError) do
-      GoodMigrations::Configuration.permit_autoloading_before_date = "abc"
+      @config.permit_autoloading_before_date = "abc"
     end
   end
 
   def test_permit_autoloading_before_date_set_date
-    GoodMigrations::Configuration.permit_autoloading_before_date = Date.new(2021, 4, 15)
+    @config.permit_autoloading_before_date = Date.new(2021, 4, 15)
 
-    assert_equal Time.new(2021, 4, 15), GoodMigrations::Configuration.permit_autoloading_before_date
+    assert_equal Time.new(2021, 4, 15), @config.permit_autoloading_before_date
   end
 
   def test_permit_autoloading_before_date_set_time
-    GoodMigrations::Configuration.permit_autoloading_before_date = Time.new(2021, 4, 20, 16, 17, 18)
+    @config.permit_autoloading_before_date = Time.new(2021, 4, 20, 16, 17, 18)
 
-    assert_equal Time.new(2021, 4, 20, 16, 17, 18), GoodMigrations::Configuration.permit_autoloading_before_date
+    assert_equal Time.new(2021, 4, 20, 16, 17, 18), @config.permit_autoloading_before_date
   end
 end

--- a/test/good_migrations_test.rb
+++ b/test/good_migrations_test.rb
@@ -16,6 +16,7 @@ class GoodMigrationsTest < Minitest::Test
       _, stderr, status = shell("AUTOLOADER=#{autoloader} bundle exec rake db:drop db:create db:migrate")
 
       assert_match(/GoodMigrations::LoadError: Rails attempted to auto-load:/, stderr)
+      assert_match(/20160202182520_change_pants_dangerously.rb/, stderr)
       assert_match(/example\/app\/models\/pant.rb/, stderr)
       refute_equal 0, status.exitstatus
     end
@@ -31,6 +32,15 @@ class GoodMigrationsTest < Minitest::Test
 
       assert_match "This many pants: 0 pants", stdout
       assert_equal 0, status.exitstatus
+    end
+
+    define_method "test_permit_autoload_before_date_#{autoloader}" do
+      _, stderr, status = shell("PERMIT_BEFORE_DATE=20170101000000 AUTOLOADER=#{autoloader} bundle exec rake db:drop db:create db:migrate")
+
+      assert_match(/GoodMigrations::LoadError: Rails attempted to auto-load:/, stderr)
+      assert_match(/20170102150000_change_shirts_dangerously.rb/, stderr)
+      assert_match(/example\/app\/models\/shirt.rb/, stderr)
+      refute_equal 0, status.exitstatus
     end
   end
 

--- a/test/good_migrations_test.rb
+++ b/test/good_migrations_test.rb
@@ -1,13 +1,6 @@
 require "test_helper"
 
 class GoodMigrationsTest < Minitest::Test
-  def setup
-    @script_setup = <<-BASH
-      cd example
-      bundle
-    BASH
-  end
-
   def test_that_it_has_a_version_number
     refute_nil ::GoodMigrations::VERSION
   end

--- a/test/good_migrations_test.rb
+++ b/test/good_migrations_test.rb
@@ -47,8 +47,7 @@ class GoodMigrationsTest < Minitest::Test
     script = <<-SCRIPT
       export BUNDLE_GEMFILE="Gemfile"
       export RAILS_ENV="development"
-      rm -f Gemfile.lock db/*.sqlite3
-      bundle install
+      rm -f db/*.sqlite3
       #{command}
     SCRIPT
     Bundler.with_unbundled_env do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,3 +4,13 @@ require "good_migrations"
 require "minitest/autorun"
 require "open3"
 require "pry"
+
+pre_test_setup_script = <<-SCRIPT
+  export BUNDLE_GEMFILE="Gemfile"
+  export RAILS_ENV="development"
+  rm -f Gemfile.lock
+  bundle install
+SCRIPT
+Bundler.with_unbundled_env do
+  Open3.capture3(pre_test_setup_script, chdir: "example")
+end


### PR DESCRIPTION
As discussed in https://github.com/testdouble/good-migrations/issues/25, this adds a basic configuration system and the `permit_autoload_date_before` configuration.

I didn't do the callable configuration part, as I would prefer to first add some easy to code configurations and then see if it still feels useful. This way, I can also have some feedback on how I've been doing things up to now.

There are a few unrelated changes that are just general improvement to the gem. They can be removed if you prefer, but I think they are clear improvements. Each commit is a coherent change, so you can view commit by commit.
