### PR TITLE
Add a configuration for the error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,17 @@ GoodMigrations.config do |config|
   #
   # Accepts parseable time strings as well as `Date` & `Time` objects
   # config.permit_autoloading_before = "20140728132502"
+
+  # Setting `load_error_message` will change error message that is be raised
+  # if a migration attempts to autoload.
+  # The %{attempted_path} format parameter is available to indicate the
+  # path of the file that would have been autoloaded.
+  # The default message is quite exhaustive, but this setting can be useful to
+  # add a some information specific to your application at the end if you use `+=`.
+  #
+  # config.load_error_message = <<~MSG
+  #   A migration tried to load this path: %{attempted_path}
+  # MSG
 end
 ```
 

--- a/lib/good_migrations/configuration.rb
+++ b/lib/good_migrations/configuration.rb
@@ -31,7 +31,50 @@ module GoodMigrations
       @permit_autoloading_before = value
     end
 
+    # The error message that will be raised if a migration attempts to autoload.
+    # The %{attempted_path} format parameter is available to indicate the
+    # path of the file that would have been autoloaded.
+    attr_accessor :load_error_message
+
     def initialize
+      @load_error_message = <<~MSG
+        Rails attempted to auto-load:
+
+        %{attempted_path}
+
+        Which is in your project's `app/` directory. The good_migrations
+        gem was designed to prevent this, because migrations are intended
+        to be immutable and safe-to-run for the life of your project, but
+        code in `app/` is liable to change at any time.
+
+        The most common reason for this error is that you may be referencing an
+        ActiveRecord model inside the migration in order to use the ActiveRecord API
+        to implement a data migration by querying and updating objects.
+
+        For instance, if you want to access a model "User" in your migration, it's safer
+        to redefine the class inside the migration instead, like this:
+
+        class MakeUsersOlder < ActiveRecord::Migration
+          class User < ActiveRecord::Base
+            # Define whatever you need on the User beyond what AR adds automatically
+          end
+
+          def up
+            User.find_each do |user|
+              user.update!(:age => user.age + 1)
+            end
+          end
+
+          def down
+            #...
+          end
+        end
+
+        For more information, visit:
+
+        https://github.com/testdouble/good-migrations
+
+      MSG
       @permit_autoloading_before = nil
     end
   end

--- a/lib/good_migrations/raises_load_error.rb
+++ b/lib/good_migrations/raises_load_error.rb
@@ -1,44 +1,8 @@
 module GoodMigrations
   class RaisesLoadError
     def raise!(path)
-      raise GoodMigrations::LoadError, <<-ERROR.strip_heredoc
-        Rails attempted to auto-load:
-
-        #{path}
-
-        Which is in your project's `app/` directory. The good_migrations
-        gem was designed to prevent this, because migrations are intended
-        to be immutable and safe-to-run for the life of your project, but
-        code in `app/` is liable to change at any time.
-
-        The most common reason for this error is that you may be referencing an
-        ActiveRecord model inside the migration in order to use the ActiveRecord API
-        to implement a data migration by querying and updating objects.
-
-        For instance, if you want to access a model "User" in your migration, it's safer
-        to redefine the class inside the migration instead, like this:
-
-        class MakeUsersOlder < ActiveRecord::Migration
-          class User < ActiveRecord::Base
-            # Define whatever you need on the User beyond what AR adds automatically
-          end
-
-          def up
-            User.find_each do |user|
-              user.update!(:age => user.age + 1)
-            end
-          end
-
-          def down
-            #...
-          end
-        end
-
-        For more information, visit:
-
-        https://github.com/testdouble/good-migrations
-
-      ERROR
+      error_message = format(GoodMigrations.config.load_error_message, attempted_path: path)
+      raise GoodMigrations::LoadError, error_message
     end
   end
 end


### PR DESCRIPTION
I would like to be able to configure the message for these reasons:
* I have helpers available in my migrations to help for migrations that need to deal with translations. (We have a table for user-provided translations related to some models)
* I would like to provide additional guidance and links for useful references.

I didn't really know how to test this because `RaisesLoadError` just uses `GoodMigrations.config`. I could refactor `RaisesLoadError` to have an `initialize` with a config parameter, but as a PR submitter, it's always awkward to change the structure of a project like that without first having the agreement of the maintainer. What do you think?