### PR TITLE
Tiny tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,7 @@ Because this gem works by augmenting the auto-loader, it will not work if your
 Rails environment (development, by default) is configured to eager load your
 application's classes (see:
 [config.eager_load](http://edgeguides.rubyonrails.org/configuring.html#rails-general-configuration)).
+
+For the same reason, if you have initializers or other code which use/load models
+before the migrations, those models will be available in the migrations and will
+not raise when used.

--- a/good_migrations.gemspec
+++ b/good_migrations.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "Referencing code in app/ from a database migration risks breaking the migration when your app code changes; this gem prevents that mistake"
   spec.homepage = "https://github.com/testdouble/good-migrations"
   spec.license = "MIT"
+  spec.required_ruby_version = ">= 2.3.0"
 
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir = "exe"


### PR DESCRIPTION
Just two little tweaks I made as I worked on other things on the gem.

* I think it's important to have a clear required_ruby_version in the gem_spec.
* I think the clarification that there are many ways the models could already be loaded is important.