### PR TITLE
Fix MigrationDetails.currently_executing on Windows

### DIFF
--- a/lib/good_migrations/migration_details.rb
+++ b/lib/good_migrations/migration_details.rb
@@ -10,7 +10,10 @@ module GoodMigrations
 
       loc = caller.detect { |loc| loc.start_with?(migrate_dir_path) }
       return if loc.nil?
-      new(loc.partition(":").first)
+      
+      end_index = loc.index(":", migrate_dir_path.size)
+
+      new(loc[0...end_index])
     end
 
     def associated_time


### PR DESCRIPTION
Because Windows' path include a `:` for the drive (ex: `D:/hello/world/db/migrate/...:4:in`), the use of `partition` splits the path at the wrong place.

This uses `index` with a 2nd parameter to find the end of the path while skipping the starting part.