### PR TITLE
Add tasks back to gemspec

### DIFF
--- a/good_migrations.gemspec
+++ b/good_migrations.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.1.0"
   spec.metadata["rubygems_mfa_required"] = "true"
 
-  spec.files = `git ls-files -z -- lib CHANGELOG* LICENSE*`.split("\x0")
+  spec.files = `git ls-files -z -- lib tasks CHANGELOG* LICENSE*`.split("\x0")
   spec.executables = `git ls-files -z -- exe`.split("\x0").map { File.basename _1 }
   spec.extra_rdoc_files = `git ls-files -z -- example README*`.split("\x0")
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Hello TD friends! I was just kicking the tires on the latest version of this gem and discovered it's not automatically loading upon installation. 😅 

I haven't sunk a lot of time into this, but I think the missing tasks dir was causing good_migrations to not be activated when installed with version 0.3.0. This wouldn't have shown up in the tests because they use the gem direct from the directory. I'm not sure off the top of my head how to use a built version of the gem in the test suite, but that would prevent this class of issues from happening again.

A workaround for now is to just install the gem via bundler's github helper:
```ruby
gem "good_migrations", github: "testdouble/good_migrations"
```

This comes with all the goodies from the repo.